### PR TITLE
Fix bug with padded MD5 Digests

### DIFF
--- a/lib/Amazon/MWS/Client.pm
+++ b/lib/Amazon/MWS/Client.pm
@@ -173,7 +173,7 @@ sub define_api_method {
         if ($body) {
             $request->method('POST'); 
             $request->content($body);
-            $request->header('Content-MD5' => md5_base64($body));
+            $request->header('Content-MD5' => md5_base64($body) . '==');
             $request->content_type($args->{content_type});
         }
         else {
@@ -199,7 +199,7 @@ sub define_api_method {
 
         if (my $md5 = $response->header('Content-MD5')) {
             bad_checksum(response => $response) 
-                unless ($md5 eq md5_base64($content));
+                unless ($md5 eq md5_base64($content) . '==');
         }
 
         return $content if $spec->{raw_body};


### PR DESCRIPTION
GetReport was giving an error "unknown field response passed to constructor for class Amazon::MWS::Client::Exception::BadCheck"

This is caused by Amazon MWS sending a 4-byte-boundary-padded Content-MD5, but Digest::MD5::md5_base64 not padding to the 4-byte boundary.

This is noted in Digest::MD5 documentation: "Note that the base64 encoded string returned is not padded to be a multiple of 4 bytes long.  If you want interoperability with other base64 encoded md5 digests you might want to append the redundant string '==' to the result."

This branch adds the '==' to calls to Digest::MD5::md5_base64 to properly generate and compare MD5 digests.
